### PR TITLE
[Feature] Added message count since user last replied 

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -16,6 +16,18 @@ const commands = [
             },
         ],
     },
+    {
+        name: "messagecount", 
+        description: "Check how many messages you have sent to a user since their last reply", 
+        options: [
+            {
+                name: "user", 
+                type: 6, 
+                description: "The user to check the message count for", 
+                required: true, 
+            },
+        ],
+    },
 ];
 
 // Register commands with Discord API: 


### PR DESCRIPTION
## Summary
What is the context behind this change? (e.g. background/problem it’s solving)
- It's easy to forget how long it's been since someone you know last messaged you 
- Stay in contact with friends better

What does this change do? (ex. high-level impact)
- It allows you to check how many messages you've sent someone since they last sent a message
- Allows for better management of keeping close to the people you know 

What do each of the code-blocks/functions in this PR do? (ex. low-level description)
- Enter /messagecount and enter username to calculate message count 
- Checks that username isn't the bot or own username
- Fetches last 100 messages, then iterates through, checking if the message author matches the username, and increments the message count
- Once a message by the username is found, it returns the message count 

## Testing
**Automated Testing:**
N/A

**Manual Testing:**
[Message count](https://github.com/ThePhysic/Discord-Butler/assets/57155067/fb4ebace-2d4a-4869-8811-4a3f9f98a206)

## References
N/A
