### PR TITLE
[Feature] Check message for replies 

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ const UNREAD_TARGET_CHANNEL_ID = process.env.UNREAD_TARGET_CHANNEL_ID;
 const TODO_TARGET_CHANNEL_ID = process.env.TODO_TARGET_CHANNEL_ID;
 const TALKING_POINT_TARGET_CHANNEL_ID = process.env.TALKING_POINT_CHANNEL_ID;
 const GENERAL_CHANNEL_ID = process.env.GENERAL_CHANNEL_ID;
+const USERNAME_REGEX = /<@(\d+)>/g;
+const TODO_REGEX = /TODO/;
+const deleteTodo = [false, false];
 
 
 // Event listener for when bot is ready:
@@ -70,6 +73,83 @@ client.on("messageReactionAdd", async (reaction, user) => {
     if (reaction.emoji.name === TODO_TARGET_EMOJI) {
         emojiReactToSend(reaction.message, user, TODO_TARGET_CHANNEL_ID);
     }
+
+    // Check emojis for deleting todo:
+    const message = reaction.message.content;
+
+    if (reaction.emoji.name === DELETE_TODO_EMOJI) {
+        if (message.match(USERNAME_REGEX)[0] === `<@${user.id}>`) {
+            deleteTodo[0] = true;
+        }
+        if (message.match(USERNAME_REGEX)[1] === `<@${user.id}>`) {
+            deleteTodo[1] = true;
+        }
+        if (deleteTodo[0] === true && deleteTodo[1] === true) {
+            reaction.message.delete();
+            deleteTodo[0] = false;
+            deleteTodo[1] = false;
+        }
+    }
+});
+
+// Event listener for reactions removed from messages:
+client.on("messageReactionRemove", async (reaction, user) => {
+    // Ignore bot reactions:
+    if (user.bot) {
+        return;
+    }
+
+    // Fetch partials if necessary:
+    if (reaction.partial) {
+        try {
+            await reaction.fetch();
+        }
+        catch (error) {
+            console.error("Something went wrong when fetching the reaction: ", error);
+            return;
+        }
+    }
+
+    // Check emojis removed for deleting todo:
+    const message = reaction.message.content;
+
+    if (message.match(USERNAME_REGEX)[0] === `<@${user.id}>`) {
+        deleteTodo[0] = false;
+    }
+    if (message.match(USERNAME_REGEX)[1] === `<@${user.id}>`) {
+        deleteTodo[1] = false;
+    }
+});
+
+// Event listener for messages sent:
+client.on("messageCreate", async (message) => {
+    // Skip bot's own messages:
+    if (message.author.bot) {
+        return;
+    }
+
+
+    // Check if message is a reply:
+    if (message.reference) {
+        const originalMessageId = message.reference.messageId;
+
+        try {
+            // Fetch original message being replied to:
+            const originalMessage = await message.channel.messages.fetch(originalMessageId);
+            const originalMessageLink = `https://discord.com/channels/${originalMessage.guildId}/${originalMessage.channelId}/${originalMessage.id}`;
+
+            // Add todo:
+            if (message.content.substring(0, 5).match(TODO_REGEX)) {
+                sendTodo(originalMessage, message.author, TODO_TARGET_CHANNEL_ID);
+            }
+            else if (message.content.match(TODO_REGEX)) {
+                sendTodo(message, message.author, TODO_TARGET_CHANNEL_ID);
+            }
+    // Add todo that isn't a reply:
+    else if (message.content.match(TODO_REGEX)) {
+        sendTodo(message, message.author, TODO_TARGET_CHANNEL_ID);
+    }
+    }
     }
 });
 
@@ -103,6 +183,22 @@ const emojiReactToSend = (message, user, targetChannelId, interaction = null) =>
     if (targetChannel && targetChannel.isTextBased()) {
         const messageLink = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
         targetChannel.send(`**Message from ${message.author}**:\n**Sent over by ${user}**:\n${message.content}\n${messageLink}`);
+        if (interaction) {
+            interaction.reply(`Message pinned successfully to ${targetChannel.name}.`);
+        }
+    }
+    else {
+        console.error("Target channel not found or is not a text channel.");
+    }
+};
+
+// Function for sending todos:
+const sendTodo = (message, user, targetChannelId, interaction = null) => {
+    const targetChannel = client.channels.cache.get(targetChannelId);
+
+    if (targetChannel && targetChannel.isTextBased()) {
+        const messageLink = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
+        targetChannel.send(`**Message from ${message.author}**:\n**Sent over by ${user}**:\n**TODO:** ${message.content}\n${messageLink}`);
         if (interaction) {
             interaction.reply(`Message pinned successfully to ${targetChannel.name}.`);
         }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { Client, GatewayIntentBits, Partials } from "discord.js";
+import { Client, GatewayIntentBits, Partials, MessageCollector, ChannelType, EmbedBuilder, VoiceChannel } from "discord.js";
 
 // Initialize the bot client:
 const client = new Client({
@@ -12,6 +12,7 @@ const client = new Client({
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.GuildMessageReactions,
+        GatewayIntentBits.GuildVoiceStates, 
     ],
     partials: [
         Partials.Message,
@@ -21,13 +22,15 @@ const client = new Client({
 });
 
 // Define target emojis and channels:
-const firstTargetEmoji = "📌";
-const secondTargetEmoji = "🔖";
-const thirdTargetEmoji = "📝";
-const deleteTodoEmoji = "✅";
-const firstTargetChannelId = process.env.TARGET_CHANNEL_ID;
-const secondTargetChannelId = process.env.SECOND_TARGET_CHANNEL_ID;
-const thirdTargetChannelId = process.env.THIRD_TARGET_CHANNEL_ID;
+const PIN_TARGET_EMOJI = "📌";
+const UNREAD_TARGET_EMOJI = "🔖";
+const TODO_TARGET_EMOJI = "📝";
+const DELETE_TODO_EMOJI = "✅";
+const PIN_TARGET_CHANNEL_ID = process.env.PIN_CHANNEL_ID;
+const UNREAD_TARGET_CHANNEL_ID = process.env.UNREAD_TARGET_CHANNEL_ID;
+const TODO_TARGET_CHANNEL_ID = process.env.TODO_TARGET_CHANNEL_ID;
+const TALKING_POINT_TARGET_CHANNEL_ID = process.env.TALKING_POINT_CHANNEL_ID;
+const GENERAL_CHANNEL_ID = process.env.GENERAL_CHANNEL_ID;
 
 
 // Event listener for when bot is ready:
@@ -54,18 +57,19 @@ client.on("messageReactionAdd", async (reaction, user) => {
     }
 
     // Check if reaction emoji matches first target emoji:
-    if (reaction.emoji.name === firstTargetEmoji) {
-        emojiReactToSend(reaction.message, user, firstTargetChannelId);
+    if (reaction.emoji.name === PIN_TARGET_EMOJI) {
+        emojiReactToSend(reaction.message, user, PIN_TARGET_CHANNEL_ID);
     }
 
     // Check if reaction emoji matches second target emoji:
-    if (reaction.emoji.name === secondTargetEmoji) {
-        emojiReactToSend(reaction.message, user, secondTargetChannelId);
+    if (reaction.emoji.name === UNREAD_TARGET_EMOJI) {
+        emojiReactToSend(reaction.message, user, UNREAD_TARGET_CHANNEL_ID);
     }
 
     // Check if reaction emoji matches third target emoji:
-    if (reaction.emoji.name === thirdTargetEmoji) {
-        emojiReactToSend(reaction.message, user, thirdTargetChannelId);
+    if (reaction.emoji.name === TODO_TARGET_EMOJI) {
+        emojiReactToSend(reaction.message, user, TODO_TARGET_CHANNEL_ID);
+    }
     }
 });
 
@@ -82,7 +86,7 @@ client.on("interactionCreate", async (interaction) => {
         const messageId = options.getString("messageid");
         try {
             const message = await interaction.channel.messages.fetch(messageId);
-            emojiReactToSend(message, interaction.user, firstTargetChannelId, interaction);
+            emojiReactToSend(message, interaction.user, PIN_TARGET_CHANNEL_ID, interaction);
         } 
         catch (error) {
             console.error("Something went wrong when fetching the message: ", error);

--- a/index.js
+++ b/index.js
@@ -200,6 +200,7 @@ client.on("interactionCreate", async (interaction) => {
             await interaction.reply("Failed to pin the message. Please check the message ID and try again.");
         }
     }
+
     // Message count:
     if (commandName === "messagecount") {
         const user = options.getUser("user");
@@ -260,6 +261,41 @@ client.on("interactionCreate", async (interaction) => {
         console.log(`Counted ${messageCount} messages from ${interaction.user.username} to ${user.username}.`);
 
         await interaction.editReply(`You have sent ${messageCount} messages to ${user.username} since their last reply.`);
+    }
+
+    // Check message for replies:
+    if (commandName === "checkreply") {
+        const messageId = options.getString("messageid");
+
+        try {
+            const channel = interaction.channel;
+            const originalMessageLink = `https://discord.com/channels/${interaction.guildId}/${channel.id}/${messageId}`;
+
+            // Check for replies:
+            const replies = [];
+            const fetchedMessages = await channel.messages.fetch({ limit: 100 });
+            fetchedMessages.forEach((message) => {
+                if (message.reference && message.reference.messageId === messageId) {
+                    replies.push(message);
+                }
+            });
+
+            if (replies.length === 0) {
+                await interaction.reply(`This message ${originalMessageLink} has not been replied to.`);
+            }
+            else {
+                let replyText = `This message ${originalMessageLink} has been replied. Here are links to the replies:\n`;
+                replies.forEach((reply) => {
+                    const replyLink = `https://discord.com/channels/${interaction.guildId}/${channel.id}/${reply.id}`;
+                    replyText += `${replyLink}\n`;
+                });
+                await interaction.reply(replyText);
+            }
+        }
+        catch (error) {
+            console.error(error);
+            await interaction.reply(`An error occurred while fetching the message.`);
+        }
     }
 });
 

--- a/utils.js
+++ b/utils.js
@@ -16,6 +16,18 @@ const commands = [
             },
         ],
     },
+    {
+        name: "messagecount", 
+        description: "Check how many messages you have sent to a user since their last reply", 
+        options: [
+            {
+                name: "user", 
+                type: 6, 
+                description: "The user to check the message count for", 
+                required: true, 
+            },
+        ],
+    },
 ];
 
 // Register commands with Discord API: 

--- a/utils.js
+++ b/utils.js
@@ -28,6 +28,18 @@ const commands = [
             },
         ],
     },
+    {
+        name: "checkreply", 
+        description: "Check if a message has been replied to", 
+        options: [
+            {
+                name: "messageid", 
+                type: 3, 
+                description: "The ID of the message to check", 
+                required: true,
+            },
+        ],
+    },
 ];
 
 // Register commands with Discord API: 


### PR DESCRIPTION
## Summary
What is the context behind this change? (e.g. background/problem it’s solving)
- You can always find a message from its reply but never the other way around 
- It gets chaotic if  message has replies spanding, days, weeks, months, etc. 

What does this change do? (ex. high-level impact)
- Check if a message has been replied to and Discord Butler will provide an answer along with message links if applicable

What do each of the code-blocks/functions in this PR do? (ex. low-level description)
- Enter /checkreply and the message ID
- Last 100 messages are fetched
- If they're replies and the message they're replying to matches the one being checked, that message is stored in a list
- At the end, the messages are iterated through to provide their message links if the list isn't empty 

## Testing
**Automated Testing:**
N/A

**Manual Testing:**
[Check reply](https://github.com/ThePhysic/Discord-Butler/assets/57155067/acd82bf6-4f2f-48b6-9d82-2edc9c631494)


## References
N/A
