### PR TITLE
[Feature] Pin limit warning 

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ const firstTargetChannelId = process.env.TARGET_CHANNEL_ID;
 const secondTargetChannelId = process.env.SECOND_TARGET_CHANNEL_ID;
 const thirdTargetChannelId = process.env.THIRD_TARGET_CHANNEL_ID;
 
+const deleteTodo = [false, false];
+
 
 // Event listener for when bot is ready:
 client.once("ready", async () => {
@@ -67,6 +69,25 @@ client.on("messageReactionAdd", async (reaction, user) => {
     if (reaction.emoji.name === thirdTargetEmoji) {
         emojiReactToSend(reaction.message, user, thirdTargetChannelId);
     }
+
+    // Check emojis for deleting todo:
+    const message = reaction.message.content;
+    const regex = /<@(\d+)>/g;
+
+    if (reaction.emoji.name === deleteTodoEmoji) {
+        if (message.match(regex)[0] === `<@${user.id}>`) {
+            deleteTodo[0] = true;
+        }
+        if (message.match(regex)[1] === `<@${user.id}>`) {
+            deleteTodo[1] = true;
+        }
+        if (deleteTodo[0] === true && deleteTodo[1] === true) {
+            reaction.message.delete();
+            deleteTodo[0] = false;
+            deleteTodo[1] = false;
+        }
+    }
+});
 });
 
 // Event listener for slash commands:
@@ -99,6 +120,22 @@ const emojiReactToSend = (message, user, targetChannelId, interaction = null) =>
     if (targetChannel && targetChannel.isTextBased()) {
         const messageLink = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
         targetChannel.send(`**Message from ${message.author}**:\n**Sent over by ${user}**:\n${message.content}\n${messageLink}`);
+        if (interaction) {
+            interaction.reply(`Message pinned successfully to ${targetChannel.name}.`);
+        }
+    }
+    else {
+        console.error("Target channel not found or is not a text channel.");
+    }
+};
+
+// Function for sending todos:
+const sendTodo = (message, user, targetChannelId, interaction = null) => {
+    const targetChannel = client.channels.cache.get(targetChannelId);
+
+    if (targetChannel && targetChannel.isTextBased()) {
+        const messageLink = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
+        targetChannel.send(`**Message from ${message.author}**:\n**Sent over by ${user}**:\n**TODO:** ${message.content}\n${messageLink}`);
         if (interaction) {
             interaction.reply(`Message pinned successfully to ${targetChannel.name}.`);
         }

--- a/index.js
+++ b/index.js
@@ -287,6 +287,22 @@ client.on("voiceStateUpdate", (oldState, newState) => {
     }
 });
 
+// Event listener for message updates:
+client.on("messageUpdate", async (oldMessage, newMessage) => {
+    try {
+        if (!oldMessage.pinned && newMessage.pinned) {
+            const pinnedMessages = await newMessage.channel.messages.fetchPinned();
+            const pinnedMessageCount = pinnedMessages.size;
+            if (pinnedMessageCount >= 40) {
+                newMessage.channel.send(`Warning: The number of pinned messages is nearing its limit. Current count: ${pinnedMessageCount}`);
+            }
+        }
+    }
+    catch (error) {
+        console.error("Error fetching pinned messages: ", error);
+    }
+});
+
 // Event listener for slash commands:
 client.on("interactionCreate", async (interaction) => {
     if (!interaction.isCommand) {

--- a/index.js
+++ b/index.js
@@ -43,8 +43,6 @@ const deleteTodo = [false, false];
 let talkingPointCount = 0;
 let callRecords = {};
 
-const deleteTodo = [false, false];
-
 
 // Event listener for when bot is ready:
 client.once("ready", async () => {
@@ -287,7 +285,6 @@ client.on("voiceStateUpdate", (oldState, newState) => {
             deleteTodo[1] = false;
         }
     }
-});
 });
 
 // Event listener for slash commands:


### PR DESCRIPTION
## Summary
What is the context behind this change? (e.g. background/problem it’s solving)
- The pin limit is capped at 50, a limit too restricting for people and groups who have lots of messages to pin

What does this change do? (ex. high-level impact)
- You receive a message if the pin limit crosses the count of 40

What do each of the code-blocks/functions in this PR do? (ex. low-level description)
- Event listener is triggered if any message is updated
- If the message has been pinned, the pinned messages are fetched
- If the amount of pinned messages is 40 or more, a warning message is sent in the chat 

## Testing
**Automated Testing:**
N/A

**Manual Testing:**
![Pin limit message](https://github.com/ThePhysic/Discord-Butler/assets/57155067/df292fb3-0a75-4679-9d79-83d27de40847)
*Warning message was sent for 2 or greater messages for the purpose of easier testing in the pic above

## References
[Discord.js](https://discord.js.org/docs/packages/discord.js/14.15.3/DMMessageManager:Class#pin)
